### PR TITLE
Add color correction option

### DIFF
--- a/src/Drivers/TGA.c
+++ b/src/Drivers/TGA.c
@@ -5,6 +5,7 @@
 #include "tga.h"
 #include "misc.h"
 #include "externs.h"
+#include "myglobals.h"
 
 static void DecompressRLE(short refNum, TGAHeader* header, Handle handle)
 {
@@ -162,10 +163,14 @@ Handle LoadTGA(
 				uint8_t red   = palette[i*3 + 2];
 				uint8_t green = palette[i*3 + 1];
 				uint8_t blue  = palette[i*3 + 0];
-				gGamePalette[i] = 0x000000FF
+				uint32_t combined = 0x000000FF
 								  | (red << 24)
 								  | (green << 16)
 								  | (blue << 8);
+
+
+				RGBColor rgbColor = U32ToRGBColor(combined);
+				SetPaletteColor(&gGamePalette, i, &rgbColor);
 			}
 
 			DisposePtr(palette);

--- a/src/Headers/myglobals.h
+++ b/src/Headers/myglobals.h
@@ -35,9 +35,9 @@ static inline RGBColor U32ToRGBColor(const uint32_t color)
 {
 	return (RGBColor)
 	{
-			((color >> 24) & 0xFF) << 8,
-			((color >> 16) & 0xFF) << 8,
-			((color >> 8) & 0xFF) << 8,
+			((color >> 24) & 0xFF) * 0x101,
+			((color >> 16) & 0xFF) * 0x101,
+			((color >> 8) & 0xFF) * 0x101,
 	};
 }
 
@@ -48,6 +48,8 @@ void	InitPaletteStuff(void);
 void	FadeInGameCLUT(void);
 void	EraseCLUT(void);
 void	FadeOutGameCLUT(void);
+void	SetPaletteColorCorrection(Boolean enabled);
+void	SetPaletteColor(struct GamePalette_s *palette, int index, const RGBColor *color);
 
 			/* ANIMATION */
 

--- a/src/Headers/structures.h
+++ b/src/Headers/structures.h
@@ -14,8 +14,11 @@
 #define	MAX_WEAPONS		50				// max weapons allowed in weapon list
 
 
-typedef uint32_t GamePalette[256];
-
+typedef struct GamePalette_s
+{
+	uint32_t finalColors[256];
+	uint16_t baseColors[256][3];
+} GamePalette;
 
 
 			/* PLAYFIELD ITEM RECORD */
@@ -288,11 +291,12 @@ struct PrefsType
 	Boolean		gameTitlePowerPete;
 	Boolean		thermometerScreen;
 	Boolean		debugInfoInTitleBar;
+	Boolean		colorCorrection;
 	KeyBinding	keys[NUM_CONTROL_NEEDS];
 };
 typedef struct PrefsType PrefsType;
 
-#define PREFS_MAGIC "Mighty Mike Prefs v1"
+#define PREFS_MAGIC "Mighty Mike Prefs v2"
 
 #endif
 

--- a/src/Heart/Filter.cpp
+++ b/src/Heart/Filter.cpp
@@ -37,7 +37,7 @@ static void ConvertIndexedFramebufferToRGBA_NoFilter(int firstRow, int numRows)
 	{
 		for (int x = 0; x < VISIBLE_WIDTH; x++)
 		{
-			*(rgba++) = gGamePalette[*(indexed++)];
+			*(rgba++) = gGamePalette.finalColors[*(indexed++)];
 		}
 	}
 }
@@ -56,8 +56,8 @@ static void ConvertIndexedFramebufferToRGBA_FilterDithering(int threadNum, int f
 		{
 			if (smearFlags[x])
 			{
-				uint8_t* me		= (uint8_t*) &gGamePalette[*indexed];
-				uint8_t* next	= (uint8_t*) &gGamePalette[*(indexed+1)];
+				uint8_t* me		= (uint8_t*) &gGamePalette.finalColors[*indexed];
+				uint8_t* next	= (uint8_t*) &gGamePalette.finalColors[*(indexed+1)];
 				uint8_t* out	= (uint8_t*) rgba;
 				out[1] = (me[1] + next[1]) >> 1;
 				out[2] = (me[2] + next[2]) >> 1;
@@ -65,13 +65,13 @@ static void ConvertIndexedFramebufferToRGBA_FilterDithering(int threadNum, int f
 				smearFlags[x] = 0;			// clear for next row
 			}
 			else
-				*rgba = gGamePalette[*indexed];
+				*rgba = gGamePalette.finalColors[*indexed];
 
 			rgba++;
 			indexed++;
 		}
 
-		*rgba = gGamePalette[*indexed];		// last
+		*rgba = gGamePalette.finalColors[*indexed];		// last
 		rgba++;
 		indexed++;
 	}

--- a/src/Heart/Main.c
+++ b/src/Heart/Main.c
@@ -1258,6 +1258,7 @@ static void InitDefaultPrefs(void)
 	gGamePrefs.gameTitlePowerPete = false;
 	gGamePrefs.thermometerScreen = true;
 	gGamePrefs.debugInfoInTitleBar = false;
+	gGamePrefs.colorCorrection = true;
 	memcpy(gGamePrefs.keys, kDefaultKeyBindings, sizeof(kDefaultKeyBindings));
 }
 

--- a/src/Heart/SettingsScreen.c
+++ b/src/Heart/SettingsScreen.c
@@ -82,6 +82,7 @@ static const char* GetPadBindingName(int row, int col);
 static void OnDone(void);
 static void OnChangePlayfieldSizeViaSettings(void);
 static void OnChangeDebugInfoInTitleBar(void);
+static void OnChangeColorCorrection(void);
 static void OnResetKeys(void);
 static void OnResetGamepad(void);
 static void LayOutMenu(MenuItem* menu);
@@ -175,6 +176,16 @@ static MenuItem gVideoMenu[] =
 			.valuePtr = &gGamePrefs.filterDithering,
 			.numChoices = 2,
 			.choices = { "   raw", "   filtered" },
+		}
+	},
+	{
+		.type = kMenuItem_Cycler, .cycler =
+		{
+			.caption = "color correction",
+			.callback = OnChangeColorCorrection,
+			.valuePtr = &gGamePrefs.colorCorrection,
+			.numChoices = 2,
+			.choices = { "no", "yes" },
 		}
 	},
 	{ .type = kMenuItem_Action, .button = { .caption = "done", .callback = OnDone } },
@@ -390,6 +401,11 @@ static void OnChangePlayfieldSizeViaSettings(void)
 	InitClipRegions();
 	gScreenBlankedFlag = false;
 	LayOutMenu(gMenu);//LayOutSettingsPageBackground();
+}
+
+static void OnChangeColorCorrection(void)
+{
+	SetPaletteColorCorrection(gGamePrefs.colorCorrection);
 }
 
 static void OnChangeDebugInfoInTitleBar(void)
@@ -1143,5 +1159,6 @@ void ApplyPrefs(void)
 	OnChangePlayfieldSize();
 	SetFullscreenMode();
 	OnChangeIntegerScaling();
+	SetPaletteColorCorrection(gGamePrefs.colorCorrection);
 }
 

--- a/src/Heart/Spin.c
+++ b/src/Heart/Spin.c
@@ -276,7 +276,7 @@ short			i;
 	for (i=0; i<256; i++)
 	{
 		rgb = *rgbPtr++;								// get a color
-		gGamePalette[i] = RGBColorToU32(&rgb);			// set
+		SetPaletteColor(&gGamePalette, i, &rgb);		// set
 	}
 
 	gSpinPtr = (Ptr)rgbPtr;								// update file pointer


### PR DESCRIPTION
Adds color correction option which remaps display colors from Apple RGB profile (i.e. what the game was developed for) to sRGB (i.e. what it's more likely to be running on).  Defaults to on.

Basically this makes the game look more like it would on a '95 Mac monitor and fixes midtones being too dark/saturated.