### PR TITLE
Allow exiting high score screen with controller start button

### DIFF
--- a/src/Heart/Cinema.c
+++ b/src/Heart/Cinema.c
@@ -607,6 +607,12 @@ ObjNode		*nameObj;
 		if (GetNewSDLKeyState(SDL_SCANCODE_RETURN) || GetNewSDLKeyState(SDL_SCANCODE_KP_ENTER))			// see if done
 			goto exit;
 
+		if (gSDLController)
+		{
+			if (SDL_GameControllerGetButton(gSDLController, SDL_CONTROLLER_BUTTON_START))
+				goto exit;
+		} 
+
 					/*  SEE IF BACK CHAR */
 
 		if (GetNewSDLKeyState(SDL_SCANCODE_LEFT) || GetNewSDLKeyState(SDL_SCANCODE_BACKSPACE))

--- a/src/Heart/Cinema.c
+++ b/src/Heart/Cinema.c
@@ -604,14 +604,9 @@ ObjNode		*nameObj;
 		theChar = gTextInput[0];
 		EraseObjects();
 
-		if (GetNewSDLKeyState(SDL_SCANCODE_RETURN) || GetNewSDLKeyState(SDL_SCANCODE_KP_ENTER))			// see if done
+		if (GetNewSDLKeyState(SDL_SCANCODE_RETURN) || GetNewSDLKeyState(SDL_SCANCODE_KP_ENTER) || GetNewNeedState(kNeed_UIPause)) // see if done
 			goto exit;
 
-		if (gSDLController)
-		{
-			if (SDL_GameControllerGetButton(gSDLController, SDL_CONTROLLER_BUTTON_START))
-				goto exit;
-		} 
 
 					/*  SEE IF BACK CHAR */
 


### PR DESCRIPTION
Currently there does not seem to be a way to exit the "enter high score" screen with a controller.
This makes it effectively impossible to quit the game with just a controller.

This PR should enable exiting the high score screen by pressing start on the controller.